### PR TITLE
Add horizontal rule end

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ $ cabal new-test --enable-tests -fdev
   - e.g. "A note about the stupid context" at `compiler/basicTypes/DataCon.hs`.
   - e.g. "Note [About the NameSorts]" at `compiler/basicTypes/Name.hs`.
   - e.g. "Note [Continuation BlockId]" at `compiler/cmm/CmmNode.hs`.
+  - e.g. "Soundness checks" at `compiler/ghci/RtClosureInspect.hs`.
 
 * Collect note references
   - Collect `See Note [...]` and relate them to notes

--- a/doc/ParsingNotes.md
+++ b/doc/ParsingNotes.md
@@ -124,6 +124,16 @@ Some notes end by a subsection.
 {-
 Note [Example Note]
 ~~~~~~~~~~~~~~~~~~~
+Some notes end by a horizontal rule
+-}
+
+-------------------------------
+```
+
+```haskell
+{-
+Note [Example Note]
+~~~~~~~~~~~~~~~~~~~
 Some notes end by a indented comment.
 -}
 


### PR DESCRIPTION
Introduce a new end rule.

P.S.

Some comments include horizontal rules with spaces:

```haskell
-- --------------
```

e.g. https://gitlab.haskell.org/ghc/ghc/blob/ghc-8.6.4-release/compiler/coreSyn/CorePrep.hs#L598

Although these rules should be removed, since the judgement is very difficult and very context sensitive,  tables and sub sections use same syntax, this patch excludes these rules.