### PR TITLE
To skip layout tokens

### DIFF
--- a/doc/ParsingNotes.md
+++ b/doc/ParsingNotes.md
@@ -21,6 +21,7 @@ many notes start by multi-line comment.
 ~~~~~~~~~~~~~~~~~~~~~~
 Titles of some notes start by multi-line comment without newline.
 -}
+```
 
 ```haskell
 -- Note [Example Note]

--- a/src/GHC/Compiler/Notes/Parser/Internal.hs
+++ b/src/GHC/Compiler/Notes/Parser/Internal.hs
@@ -272,6 +272,7 @@ sinkParsingNoteComment ctx = lift await >>= \case
             let nctx = addBufferByCollecting True ns ctx
             sinkParsingNoteComment nctx
       ITblockComment s -> parseBlockComment (Just ctx) $ L p s
+      ITsemi -> sinkParsingNoteComment ctx -- skip layout tokens
       _ -> m
   where
     removeNamedTag (L p s)      = removeNamedTag' (srcSpanStart p) (srcSpanEnd p) s


### PR DESCRIPTION
If a haddock comment block follows some token, GHC insert a virtual semicolon before the comment block as module layout line.

```haskell
{-
Note [Some Note]
~~~~~~~~~~~~~
-}
{- $name
something.
-}
```

is transformed to

```haskell
{-
Note [Some Note]
~~~~~~~~~~~~~
-}
;
{- $name
something.
-}
```

So, We should skip layout tokens at parsing.

e.g. this patch fix https://ghc-compiler-notes.readthedocs.io/en/latest/notes/libraries/template-haskell/Language/Haskell/TH/Syntax.hs.html#note-name-lookup